### PR TITLE
Adjustments

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,7 @@ LANGUAGE=en
 TELEGRAM_BOT_TOKEN=<get from bot father>
 TELEGRAM_GROUP_ID=<your telegram group id or telegram channel id>
 TELEGRAM_TOPIC_ID=<not require - your telegram topic (when enable Topics in group setting)>
+SENTRY_URL=<your Sentry URL, e.g. https://sentry.io or https://sentry.example.com for self-hosted>
 SENTRY_INTEGRATION_TOKEN=<token in Custom Integrations in Sentry Setting>
 SENTRY_ORGANIZATION_SLUG=<your Sentry org slug>
 SENTRY_PROJECT_SLUG_ALLOW_LIST=<your Project slug list (Not require - split with comma `,` character)>

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ $ npm install
 
 | Name                           | Is Require | Type   | Note                                                                                                                                                                                                                                          | Value |
 | ------------------------------ | ---------- | ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----- |
-| LANGUAGE                       | Yes        | string | The language of message when send                                                                                                                                                                                                             | vi,en |
+| LANGUAGE                       | Yes        | string | The language of message when send                                                                                                                                                                                                             | vi,en,ru |
 | TELEGRAM_BOT_TOKEN             | Yes        | string | The token from @BotFather telegram check [HERE](https://core.telegram.org/bots/tutorial#obtain-your-bot-token) for see how to get this.                                                                                                       |       |
 | TELEGRAM_GROUP_ID              | Yes        | number | The id of your telegram group. You can use telegram API for check that through Postman. Check [HERE](https://stackoverflow.com/questions/32423837/telegram-bot-how-to-get-a-group-chat-id) for more detail. Normally, that start with -100... |       |
 | TELEGRAM_TOPIC_ID              | No         | number | The id of you topic if you enable Topics in group setting.                                                                                                                                                                                    |       |
+| SENTRY_URL                     | No         | string | Your Sentry URL (e.g. https://sentry.io or https://sentry.example.com for self-hosted). Defaults to https://sentry.io                                                                                                                         |       |
 | SENTRY_INTEGRATION_TOKEN       | Yes        | string | The token that geneate by sentry. Check [HERE](https://docs.sentry.io/organization/integrations/integration-platform/#permissions) for more detail.                                                                                           |       |
 | SENTRY_ORGANIZATION_SLUG       | Yes        | string | The organization slug in your sentry organization setting                                                                                                                                                                                     |       |
 | SENTRY_PROJECT_SLUG_ALLOW_LIST | No         | string | your Project slug list (Not require - split with comma `,` character)setting                                                                                                                                                                  |       |
@@ -71,9 +72,10 @@ $ npm install
    TELEGRAM_BOT_TOKEN=<get from bot father>
    TELEGRAM_GROUP_ID=<your telegram group id or telegram channel id>
    TELEGRAM_TOPIC_ID=<not require - your telegram topic (when enable Topics in group setting)>
+   SENTRY_URL=<your Sentry URL, e.g. https://sentry.io or https://sentry.example.com for self-hosted>
    SENTRY_INTEGRATION_TOKEN=<token in Custom Integrations in Sentry Setting>
    SENTRY_ORGANIZATION_SLUG=<your Sentry org slug>
-   SENTRY_PROJECT_SLUG_ALLOW_LIST=<your Project slug list (Not require - split with comma `,` charactor)>
+   SENTRY_PROJECT_SLUG_ALLOW_LIST=<your Project slug list (Not require - split with comma `,` character)>
    ```
 
 3. Run with npm
@@ -102,13 +104,14 @@ $ npm install
       -v /tmp/sentry-telegram-hook/logs:/code/logs \
       -p 3000:3000 \
       -e LANGUAGE=en \
-      -e TELEGRAM_BOT_TOKEN=<TELEGRAM_BOT_TOKEN> \ #get from bot father 
-      -e TELEGRAM_GROUP_ID=<TELEGRAM_GROUP_ID> \ #your telegram group id or telegram channel id 
-      -e TELEGRAM_TOPIC_ID=<TELEGRAM_TOPIC_ID> \ #not require - your telegram topic when enable Topics in group setting 
-      -e SENTRY_INTEGRATION_TOKEN=<SENTRY_INTEGRATION_TOKEN> \ #token in Custom Integrations in Sentry Setting 
+      -e TELEGRAM_BOT_TOKEN=<TELEGRAM_BOT_TOKEN> \ #get from bot father
+      -e TELEGRAM_GROUP_ID=<TELEGRAM_GROUP_ID> \ #your telegram group id or telegram channel id
+      -e TELEGRAM_TOPIC_ID=<TELEGRAM_TOPIC_ID> \ #not require - your telegram topic when enable Topics in group setting
+      -e SENTRY_URL=<SENTRY_URL> \ #your Sentry URL (e.g. https://sentry.io or https://sentry.example.com for self-hosted)
+      -e SENTRY_INTEGRATION_TOKEN=<SENTRY_INTEGRATION_TOKEN> \ #token in Custom Integrations in Sentry Setting
       -e SENTRY_ORGANIZATION_SLUG=<SENTRY_ORGANIZATION_SLUG> \ #your Sentry org slug
-      -e SENTRY_PROJECT_SLUG_ALLOW_LIST=<SENTRY_PROJECT_SLUG_ALLOW_LIST> \ your Project slug list (Not require - split with comma `,` character)
-      tuanngocptn/sentry-telegram-webhook:latest 
+      -e SENTRY_PROJECT_SLUG_ALLOW_LIST=<SENTRY_PROJECT_SLUG_ALLOW_LIST> \ #your Project slug list (Not require - split with comma `,` character)
+      tuanngocptn/sentry-telegram-webhook:latest
     ```
 
 - Docker compose - create the compose file with below information. More details [HERE](https://hub.docker.com/repository/docker/tuanngocptn/sentry-telegram-webhook).
@@ -127,6 +130,7 @@ $ npm install
         - TELEGRAM_BOT_TOKEN=<get from bot father>
         - TELEGRAM_GROUP_ID=<your telegram group id or telegram channel id>
         - TELEGRAM_TOPIC_ID=<not require - your telegram topic (when enable Topics in group setting)>
+        - SENTRY_URL=<your Sentry URL, e.g. https://sentry.io or https://sentry.example.com for self-hosted>
         - SENTRY_INTEGRATION_TOKEN=<token in Custom Integrations in Sentry Setting>
         - SENTRY_ORGANIZATION_SLUG=<your Sentry org slug>
         - SENTRY_PROJECT_SLUG_ALLOW_LIST=<your Project slug list (Not require - split with comma `,` character)>
@@ -152,6 +156,7 @@ $ npm install
     - TELEGRAM_BOT_TOKEN=<get from bot father>
     - TELEGRAM_GROUP_ID=<your telegram group id or telegram channel id>
     - TELEGRAM_TOPIC_ID=<not require - your telegram topic (when enable Topics in group setting)>
+    - SENTRY_URL=<your Sentry URL, e.g. https://sentry.io or https://sentry.example.com for self-hosted>
     - SENTRY_INTEGRATION_TOKEN=<token in Custom Integrations in Sentry Setting>
     - SENTRY_ORGANIZATION_SLUG=<your Sentry org slug>
     - SENTRY_PROJECT_SLUG_ALLOW_LIST=<your Project slug list (Not require - split with comma `,` character)>
@@ -179,6 +184,7 @@ $ npm install
     - TELEGRAM_BOT_TOKEN=<get from bot father>
     - TELEGRAM_GROUP_ID=<your telegram group id or telegram channel id>
     - TELEGRAM_TOPIC_ID=<not require - your telegram topic (when enable Topics in group setting)>
+    - SENTRY_URL=<your Sentry URL, e.g. https://sentry.io or https://sentry.example.com for self-hosted>
     - SENTRY_INTEGRATION_TOKEN=<token in Custom Integrations in Sentry Setting>
     - SENTRY_ORGANIZATION_SLUG=<your Sentry org slug>
     - SENTRY_PROJECT_SLUG_ALLOW_LIST=<your Project slug list (Not require - split with comma `,` character)>

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -84,13 +84,14 @@ export class AppController {
           webUrl = error.web_url || '';
 
           // Извлекаем имя проекта из issue_url или url
-          if (error.issue_url) {
-            const match = error.issue_url.match(/\/projects\/([^/]+)\/([^/]+)\//);
+          if (error.url) {
+            const match = error.url.match(/\/projects\/([^/]+)\/([^/]+)\//);
             if (match) {
-              projectName = match[2];
+              projectName = match[2]; // sit30-php
               projectSlug = match[2];
             }
           }
+          
 
           // Извлекаем данные из contexts
           const contexts = error.contexts || {};

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -35,27 +35,80 @@ export class AppController {
     const running = async () => {
       try {
         this.logger.info(reqBody);
-        const { issue } = reqBody.data;
-        if (!this.appHelper.isAllowNotification(issue.project.slug)) {
+
+        const action = reqBody.action;
+        const data = reqBody.data;
+
+        let title: string;
+        let culprit: string;
+        let projectName: string;
+        let projectSlug: string;
+        let issueId: string;
+        let webUrl: string;
+
+        // Handle different event types
+        if (data.issue) {
+          // issue.created, issue.resolved, etc.
+          title = data.issue.title;
+          culprit = data.issue.culprit;
+          projectName = data.issue.project?.name || 'Unknown';
+          projectSlug = data.issue.project?.slug || '';
+          issueId = data.issue.id;
+          webUrl = data.issue.web_url || '';
+        } else if (data.event) {
+          // event_alert.triggered
+          title = data.event.title;
+          culprit = data.event.culprit;
+          projectName = data.event.project?.name || 'Unknown';
+          projectSlug = data.event.project?.slug || '';
+          issueId = data.event.issue_id;
+          webUrl = data.event.web_url || '';
+        } else if (data.error) {
+          // error.created
+          title = data.error.title;
+          culprit = data.error.culprit;
+          projectName = 'Unknown';
+          projectSlug = '';
+          issueId = data.error.issue_id;
+          webUrl = data.error.web_url || '';
+        } else {
+          this.logger.info('Unknown event structure, skipping');
+          return;
+        }
+
+        if (projectSlug && !this.appHelper.isAllowNotification(projectSlug)) {
           this.logger.info(
-            'This app slug "${issue.project.slug}" is not allowed for push notifications !!!',
+            `This app slug "${projectSlug}" is not allowed for push notifications`,
           );
           return;
         }
-        const issueDetails = await this.appService.getIssueDetail(issue.id);
+
+        // Try to get issue details, but don't fail if it doesn't work
+        let issueDetails = {};
+        try {
+          if (issueId) {
+            issueDetails = await this.appService.getIssueDetail(issueId);
+          }
+        } catch (ex) {
+          this.logger.warn('Failed to get issue details, continuing without them');
+        }
+
         const hookMessageData: HookMessageDataType = {
-          issueAction: reqBody.action,
-          appName: issue.project.name,
-          title: issue.title,
-          errorPosition: issue.culprit,
-          detailLink: `https://${process.env.SENTRY_ORGANIZATION_SLUG}.sentry.io/issues/${issue.id}`,
+          issueAction: action,
+          appName: projectName,
+          title: title,
+          errorPosition: culprit,
+          detailLink: webUrl || `${process.env.SENTRY_URL}/organizations/${process.env.SENTRY_ORGANIZATION_SLUG}/issues/${issueId}/`,
           ...issueDetails,
         };
-        this.appService.sentTelegramMessage(hookMessageData);
+
+        await this.appService.sentTelegramMessage(hookMessageData);
+        this.logger.info('Telegram message sent successfully');
       } catch (ex) {
         this.logger.error(ex);
       }
     };
+
     running();
     return reqBody.installation || { message: 'success' };
   }

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -73,12 +73,12 @@ export class AppController {
           issueId = event.issue_id;
           webUrl = event.web_url || '';
 
-          // project может быть объектом или числом
+          // project can be an object or a number
           if (typeof event.project === 'object' && event.project) {
             projectName = event.project.name || 'Unknown';
             projectSlug = event.project.slug || '';
           } else {
-            // Извлекаем имя проекта из URL
+            // Extract the project name from the URL
             if (event.url) {
               const match = event.url.match(/\/projects\/([^/]+)\/([^/]+)\//);
               if (match) {
@@ -88,12 +88,12 @@ export class AppController {
             }
           }
 
-          // Извлекаем данные из contexts (аналогично data.error)
+          // Extract data from contexts (similar to data.error)
           const contexts = event.contexts || {};
           const exception = event.exception?.values?.[0];
           const frame = exception?.stacktrace?.frames?.slice(-1)[0];
 
-          // Позиция с полным путём и номером строки
+          // Position with full path and line number
           if (frame) {
             const filename = frame.abs_path || frame.filename || 'unknown';
             const lineno = frame.lineno || '?';
@@ -101,7 +101,7 @@ export class AppController {
             culprit = `${filename}:${lineno}${func}`;
           }
 
-          // Формируем issueDetails из данных event
+          // Form issueDetails from event data
           issueDetails = {
             environment: event.environment || '',
             release: event.release || '',
@@ -118,14 +118,14 @@ export class AppController {
           };
 
         } else if (data.error) {
-          // error.created - самый подробный тип
+          // error.created - the most detailed type
           const error = data.error as any;
           title = error.title;
           culprit = error.culprit;
           issueId = error.issue_id;
           webUrl = error.web_url || '';
 
-          // Извлекаем имя проекта из issue_url или url
+          // Extract the project name from issue_url or url
           if (error.url) {
             const match = error.url.match(/\/projects\/([^/]+)\/([^/]+)\//);
             if (match) {
@@ -135,12 +135,12 @@ export class AppController {
           }
           
 
-          // Извлекаем данные из contexts
+          // Extracting data from contexts
           const contexts = error.contexts || {};
           const exception = error.exception?.values?.[0];
-          const frame = exception?.stacktrace?.frames?.slice(-1)[0]; // последний фрейм - место ошибки
+          const frame = exception?.stacktrace?.frames?.slice(-1)[0]; // last frame - location of error
 
-          // Позиция с полным путём и номером строки
+          // Position with full path and line number
           if (frame) {
             const filename = frame.abs_path || frame.filename || 'unknown';
             const lineno = frame.lineno || '?';
@@ -148,7 +148,7 @@ export class AppController {
             culprit = `${filename}:${lineno}${func}`;
           }
 
-          // Формируем issueDetails из данных error
+          // Form issueDetails from error data
           issueDetails = {
             environment: error.environment || 'unknown',
             release: error.release || 'none',
@@ -197,7 +197,7 @@ export class AppController {
   }
 
   private formatOs(contexts: any): string {
-    // Приоритет: серверная ОС, потом клиентская
+    // Priority: server OS, then client OS
     const serverOs = contexts.os;
     const clientOs = contexts.client_os;
     

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -106,5 +106,8 @@ export type HookMessageDataType = {
   mechanism?: string;
   device?: string;
   os?: string;
+  browser?: string;
+  runtime?: string;
+  url?: string;
   detailLink?: string;
 };

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -29,41 +29,54 @@ export type SentryMetadataType = {
   initial_priority: number;
 };
 
+export type SentryEventType = {
+  title?: string;
+  culprit?: string;
+  project?: SentryProjectType;
+  issue_id?: string;
+  web_url?: string;
+};
+
+export type SentryIssueType = {
+  id: string;
+  shareId: string;
+  shortId: string;
+  title: string;
+  culprit: string;
+  permalink: string;
+  logger: string;
+  level: string;
+  status: string;
+  statusDetails: any;
+  substatus: string;
+  isPublic: boolean;
+  platform: string;
+  project: SentryProjectType;
+  type: string;
+  metadata: SentryMetadataType;
+  numComments: number;
+  assignedTo: string;
+  isBookmarked: boolean;
+  isSubscribed: boolean;
+  subscriptionDetails: string;
+  hasSeen: boolean;
+  annotations: any;
+  issueType: string;
+  issueCategory: string;
+  priority: string;
+  priorityLockedAt: string;
+  isUnhandled: boolean;
+  count: string;
+  userCount: number;
+  firstSeen: string;
+  lastSeen: string;
+  web_url?: string;
+};
+
 export type SentryRequestDataType = {
-  issue: {
-    id: string;
-    shareId: string;
-    shortId: string;
-    title: string;
-    culprit: string;
-    permalink: string;
-    logger: string;
-    level: string;
-    status: string;
-    statusDetails: any;
-    substatus: string;
-    isPublic: boolean;
-    platform: string;
-    project: SentryProjectType;
-    type: string;
-    metadata: SentryMetadataType;
-    numComments: number;
-    assignedTo: string;
-    isBookmarked: boolean;
-    isSubscribed: boolean;
-    subscriptionDetails: string;
-    hasSeen: boolean;
-    annotations: any;
-    issueType: string;
-    issueCategory: string;
-    priority: string;
-    priorityLockedAt: string;
-    isUnhandled: boolean;
-    count: string;
-    userCount: number;
-    firstSeen: string;
-    lastSeen: string;
-  };
+  issue?: SentryIssueType;
+  event?: SentryEventType;
+  error?: SentryEventType;
 };
 
 export type SentryActorType = {

--- a/src/app.helper.ts
+++ b/src/app.helper.ts
@@ -1,36 +1,36 @@
 import { Injectable } from '@nestjs/common';
 import { HookMessageDataType } from './app';
-import { generateHookMessageEn, generateHookMessageVi } from './app.utils';
+import { generateHookMessageEn, generateHookMessageVi, generateHookMessageRu } from './app.utils';
 
 @Injectable()
 export class AppHelper {
   generateHookMessage(data: HookMessageDataType): string {
-    if ('vi' === process.env.LANGUAGE) {
-      return generateHookMessageVi(data);
+    switch (process.env.LANGUAGE) {
+      case 'vi':
+        return generateHookMessageVi(data);
+      case 'ru':
+        return generateHookMessageRu(data);
+      default:
+        return generateHookMessageEn(data);
     }
-    return generateHookMessageEn(data);
   }
 
   isAllowNotification(projectSlug: string): boolean {
     const sentryProjectSlugFilter: string =
       process.env.SENTRY_PROJECT_SLUG_ALLOW_LIST;
-
     if (!sentryProjectSlugFilter) {
       return true;
     }
-
     const projectSlugFilter = sentryProjectSlugFilter
       .split(',')
       .map((item) => item.trim())
       .filter((item) => !!item);
-
     if (
       projectSlugFilter.length > 0 &&
       !projectSlugFilter.includes(projectSlug)
     ) {
       return false;
     }
-
     return true;
   }
 }

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -34,7 +34,8 @@ export class AppService {
   async getIssueDetail(issueId): Promise<HookMessageDataType> {
     const { data } = await axios({
       method: 'get',
-      url: `https://sentry.io/api/0/organizations/${process.env.SENTRY_ORGANIZATION_SLUG}/issues/${issueId}/tags/`,
+      url: `${process.env.SENTRY_URL || 'https://sentry.io'}/api/0/organizations/${process.env.SENTRY_ORGANIZATION_SLUG}/issues/${issueId}/tags/`,
+      // url: `https://sentry.io/api/0/organizations/${process.env.SENTRY_ORGANIZATION_SLUG}/issues/${issueId}/tags/`,
       headers: {
         Authorization: `Bearer ${process.env.SENTRY_INTEGRATION_TOKEN}`,
       },

--- a/src/app.service.ts
+++ b/src/app.service.ts
@@ -35,7 +35,6 @@ export class AppService {
     const { data } = await axios({
       method: 'get',
       url: `${process.env.SENTRY_URL || 'https://sentry.io'}/api/0/organizations/${process.env.SENTRY_ORGANIZATION_SLUG}/issues/${issueId}/tags/`,
-      // url: `https://sentry.io/api/0/organizations/${process.env.SENTRY_ORGANIZATION_SLUG}/issues/${issueId}/tags/`,
       headers: {
         Authorization: `Bearer ${process.env.SENTRY_INTEGRATION_TOKEN}`,
       },

--- a/src/app.utils.ts
+++ b/src/app.utils.ts
@@ -4,15 +4,13 @@ export function generateHookMessageEn(data: HookMessageDataType) {
   const _data: HookMessageDataType = escapedHookMessageData(data);
   return `
 *💣 Issue ${_data.issueAction}:*
-
-\\- *App name:* ${_data.appName || 'none'}
+\\- *Project:* ${_data.appName || 'none'}
 \\- *Title:* ${_data.title || 'none'}
 \\- *Position:* ${_data.errorPosition || 'none'}
 \\- *Environment:* ${_data.environment || 'none'}
 \\- *Version:* ${_data.release || 'none'}
 \\- *Devices:* ${_data.device || 'none'}
 \\- *Operation System:* ${_data.os || 'none'}
-
 *Detail:* [HERE](${_data.detailLink})
   `;
 }
@@ -21,7 +19,6 @@ export function generateHookMessageVi(data: HookMessageDataType) {
   const _data: HookMessageDataType = escapedHookMessageData(data);
   return `
 *💣 Lỗi về \\(${_data.issueAction || 'none'}\\):*
-
 \\- *Tên app:* ${_data.appName || 'none'}
 \\- *Tiêu đề:* ${_data.title || 'none'}
 \\- *Lỗi ở:* ${_data.errorPosition || 'none'}
@@ -29,8 +26,22 @@ export function generateHookMessageVi(data: HookMessageDataType) {
 \\- *Phiên bản:* ${_data.release || 'none'}
 \\- *Thiết bị:* ${_data.device || 'none'}
 \\- *Hệ điều hành:* ${_data.os || 'none'}
-
 *Xem chi tiết:* [TẠI ĐÂY](${_data.detailLink}) 
+  `;
+}
+
+export function generateHookMessageRu(data: HookMessageDataType) {
+  const _data: HookMessageDataType = escapedHookMessageData(data);
+  return `
+*💣 Ошибка \\(${_data.issueAction || 'none'}\\):*
+\\- *Проект:* ${_data.appName || 'none'}
+\\- *Заголовок:* ${_data.title || 'none'}
+\\- *Позиция:* ${_data.errorPosition || 'none'}
+\\- *Окружение:* ${_data.environment || 'none'}
+\\- *Версия:* ${_data.release || 'none'}
+\\- *Устройство:* ${_data.device || 'none'}
+\\- *ОС:* ${_data.os || 'none'}
+*Подробнее:* [ТУТ](${_data.detailLink})
   `;
 }
 

--- a/src/app.utils.ts
+++ b/src/app.utils.ts
@@ -41,7 +41,7 @@ export function generateHookMessageRu(data: HookMessageDataType) {
 \\- *Версия:* ${_data.release || 'none'}
 \\- *Устройство:* ${_data.device || 'none'}
 \\- *ОС:* ${_data.os || 'none'}
-*Подробнее:* [ТУТ](${_data.detailLink})
+*Подробнее:* [ЗДЕСЬ](${_data.detailLink})
   `;
 }
 


### PR DESCRIPTION
All done!

Changes to sentry-telegram-webhook
Repository: https://github.com/itnos/sentry-telegram-webhook (fork of tuanngocptn/sentry-telegram-webhook)
Problem
Original webhook did not work with self-hosted Sentry 25.11:

Hardcoded URL sentry.io
Did not support data.error and data.event structures from Alert Rules
Crashed on failed API requests to Sentry

Modified files
1. src/app.service.ts

Replaced https://sentry.io with process.env.SENTRY_URL

2. src/app.controller.ts

Added support for data.event (Alert Rules) and data.error (webhooks)
Extract project name from event URL
Extract error position with line number from stacktrace
Extract environment, device, OS from contexts
Made getIssueDetail() optional (does not crash on API error)
Added helper methods formatOs() and formatUser()

3. src/app.d.ts

Added types SentryEventType and SentryIssueType
SentryRequestDataType now supports issue?, event?, error?

4. src/app.utils.ts

Changed "App name" to "Project"
Added generateHookMessageRu() function for Russian language

5. src/app.helper.ts

Added support for LANGUAGE=ru

Environment variables
SENTRY_URL=https://sentry.example.com  # new variable
LANGUAGE=ru                          # new option